### PR TITLE
fix `javascript` macros not doing anything

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -135,7 +135,7 @@ async function executeMacro(name) {
                     javacsriptAction = action.javascript
                 // if its an array, convert the array to a string
                 } else if (action.javascript instanceof Array) {
-                    let javacsriptAction = action.javascript.join("\n")
+                    javacsriptAction = action.javascript.join("\n")
                 } else {
                     window.showWarningMessage(
                         `For the ${name} macro\nThere's a "javascript" section thats not a string or an array but instead: ${JSON.stringify(action.javascript)}`

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "macro-commander (Command Runner)",
   "description": "Keybindings to commandline scripts, along with any VS Code command",
   "icon": "icon.png",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "publisher": "jeff-hykin",
   "repository": {
     "type": "git",


### PR DESCRIPTION
When you moved some stuff around, I'm guessing this file now gets treated as a module or something and it broke executing `javascript` based macros. The extra `let` defines a new shadowed variable when you really want it to modify the initial definition of `javacsriptAction`. Before this fix, the `javacsriptAction` is just an empty string and, therefore, does nothing.

I tested this locally and it seems to work fine, but of course you'll still need to merge the change, pull it down locally, and publish the new version.

Let me know if you want/need me to do anything else!